### PR TITLE
Leveraging local storage for updates across tabs

### DIFF
--- a/src/components/EditPatientForm/EditPatientForm.js
+++ b/src/components/EditPatientForm/EditPatientForm.js
@@ -1,15 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getPatients, initDb, updatePatient } from '../../services/databaseService';
-import {
-  InputField,
-  SelectField,
-  genderOptions,
-  bloodGroupOptions,
-  calculateAge,
-} from '../../helpers/formHelpers';
+import { InputField, SelectField, genderOptions, bloodGroupOptions, calculateAge } from '../../helpers/formHelpers';
 import { useSnackbar } from 'notistack';
-import { FaUser, FaCalendarAlt, FaVenusMars, FaPhone, FaEnvelope, FaMapMarkerAlt, FaUserShield, FaSyringe, FaNotesMedical, FaProcedures, FaSave,} from "react-icons/fa";
+import { FaUser, FaCalendarAlt, FaVenusMars, FaPhone, FaEnvelope, FaMapMarkerAlt, FaUserShield, FaSyringe, FaNotesMedical, FaProcedures, FaSave} from "react-icons/fa";
 
 const EditPatientForm = ({ onPatientUpdated }) => {
   const { enqueueSnackbar } = useSnackbar();

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "react-router-dom";
 import Navigation from "../Navigation/Navigation";
 import MedblocksLogo from "../../medblock_logo.webp";

--- a/src/components/PatientForm/PatientForm.js
+++ b/src/components/PatientForm/PatientForm.js
@@ -1,13 +1,7 @@
 import React, { useState } from 'react';
-import {
-  InputField,
-  SelectField,
-  genderOptions,
-  bloodGroupOptions,
-  calculateAge,
-} from '../../helpers/formHelpers';
+import { InputField, SelectField, genderOptions, bloodGroupOptions, calculateAge } from '../../helpers/formHelpers';
 import { useSnackbar } from 'notistack';
-import { FaUser, FaCalendarAlt, FaVenusMars, FaPhone, FaEnvelope, FaMapMarkerAlt, FaUserShield, FaSyringe, FaNotesMedical, FaProcedures, FaSave,} from "react-icons/fa";
+import { FaUser, FaCalendarAlt, FaVenusMars, FaPhone, FaEnvelope, FaMapMarkerAlt, FaUserShield, FaSyringe, FaNotesMedical, FaProcedures, FaSave} from "react-icons/fa";
 
 const PatientForm = ({ onAddPatient }) => {
   const { enqueueSnackbar } = useSnackbar();
@@ -48,6 +42,14 @@ const PatientForm = ({ onAddPatient }) => {
       Object.entries(patient).map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
     );
 
+    const enteredDate = new Date(cleaned.dob);
+    const today = new Date();
+
+    // Validate DOB is not in the future
+    if (enteredDate > today) {
+      enqueueSnackbar('Please enter a valid Date of Birth.', { variant: 'warning' });
+      return;
+    }
 
     try {
       await onAddPatient(cleaned);
@@ -81,8 +83,8 @@ const PatientForm = ({ onAddPatient }) => {
         </h3>
 
         <InputField id="name" name="name" value={patient.name} onChange={handleChange} required icon={FaUser} label="Full Name" />
-        <InputField id="dob" name="dob" type="date" value={patient.dob} onChange={handleChange} icon={FaCalendarAlt} label="Date of Birth" />
-        <InputField id="age" name="age" type="number" value={patient.age} onChange={() => {}} icon={FaCalendarAlt} label="Age" />
+        <InputField id="dob" name="dob" type="date" value={patient.dob} onChange={handleChange} icon={FaCalendarAlt} label="Date of Birth" max={new Date().toISOString().split("T")[0]}/>
+        <InputField id="age" name="age" type="number" value={patient.age} onChange={() => {}} icon={FaCalendarAlt} label="Age(Auto from Date of Birth)" />
         <SelectField id="gender" name="gender" value={patient.gender} onChange={handleChange} required icon={FaVenusMars} label="Gender" options={genderOptions} />
         <InputField id="phone" name="phone" type="tel" value={patient.phone} onChange={handleChange} required icon={FaPhone} label="Phone Number" />
         <InputField id="email" name="email" type="email" value={patient.email} onChange={handleChange} icon={FaEnvelope} label="Email Address" />

--- a/src/components/PatientList/PatientList.js
+++ b/src/components/PatientList/PatientList.js
@@ -56,8 +56,11 @@ const PatientCard = ({ patient, index, onDelete }) => {
     <div
       className="relative bg-white border border-[#BAD6EB]/30 rounded-xl shadow-sm p-4 flex items-center justify-between"
       style={{
+        animationName: 'fadeInUp',
+        animationDuration: '0.5s',
+        animationTimingFunction: 'ease-out',
+        animationFillMode: 'forwards',
         animationDelay: `${index * 50}ms`,
-        animation: 'fadeInUp 0.5s ease-out forwards',
       }}
     >
       <div className="flex items-center gap-4 cursor-pointer" onClick={() => navigate(`/patients/${patient.id}`)}>

--- a/src/components/QueryForm/QueryForm.js
+++ b/src/components/QueryForm/QueryForm.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { queryPatients } from '../../services/databaseService';
-import {
-    FaTerminal, FaDatabase, FaCode, FaPlay
-} from 'react-icons/fa';
+import { FaTerminal, FaDatabase, FaCode, FaPlay } from 'react-icons/fa';
 
 const QueryForm = ({ onQueryExecuted }) => {
   const [sql, setSql] = useState('');

--- a/src/services/databaseService.js
+++ b/src/services/databaseService.js
@@ -57,33 +57,84 @@ export const addPatient = async (patient) => {
       bloodgroup, allergies, conditions
     ]
   );
+
+  const updated = await getPatients();
+  localStorage.setItem('patients', JSON.stringify(updated));
 };
 
 export const updatePatient = async (id, patient) => {
   await executeQuery(
-		`UPDATE patients SET 
-			name = $1, dob = $2, age = $3, gender = $4, phone = $5, email = $6, address = $7,
-			emergencycontactname = $8, emergencycontactrelation = $9, emergencycontactphone = $10,
-			bloodgroup = $11, allergies = $12, conditions = $13,
-			modified_at = CURRENT_TIMESTAMP
-			WHERE id = $14`,
-		[
-			patient.name, patient.dob, patient.age, patient.gender, patient.phone, patient.email, patient.address,
-			patient.emergencycontactname, patient.emergencycontactrelation, patient.emergencycontactphone,
-			patient.bloodgroup, patient.allergies, patient.conditions,
-			id
-		]
-	);
+    `UPDATE patients SET 
+      name = $1, dob = $2, age = $3, gender = $4, phone = $5, email = $6, address = $7,
+      emergencycontactname = $8, emergencycontactrelation = $9, emergencycontactphone = $10,
+      bloodgroup = $11, allergies = $12, conditions = $13,
+      modified_at = CURRENT_TIMESTAMP
+    WHERE id = $14`,
+    [
+      patient.name, patient.dob, patient.age, patient.gender, patient.phone, patient.email, patient.address,
+      patient.emergencycontactname, patient.emergencycontactrelation, patient.emergencycontactphone,
+      patient.bloodgroup, patient.allergies, patient.conditions,
+      id
+    ]
+  );
+
+  const updated = await getPatients();
+  localStorage.setItem('patients', JSON.stringify(updated));
 };
 
 export const getPatients = async () => {
-  return await executeQuery('SELECT * FROM patients ORDER BY created_at DESC');
+  const fromDb = await executeQuery('SELECT * FROM patients ORDER BY created_at DESC');
+  return fromDb;
+};
+
+export const deletePatient = async (id) => {
+  await executeQuery(`DELETE FROM patients WHERE id = $1`, [id]);
+  const updated = await getPatients();
+  localStorage.setItem('patients', JSON.stringify(updated));
 };
 
 export const queryPatients = async (sql) => {
   return await executeQuery(sql);
 };
 
-export const deletePatient = async (id) => {
-  await executeQuery(`DELETE FROM patients WHERE id = $1`, [id]);
+export const syncLocalStorageToDb = async () => {
+  const data = localStorage.getItem('patients');
+  if (!data) return;
+
+  const patients = JSON.parse(data);
+  for (const p of patients) {
+    await executeQuery(
+      `INSERT INTO patients (
+        id, name, dob, age, gender, phone, email, address,
+        emergencycontactname, emergencycontactrelation, emergencycontactphone,
+        bloodgroup, allergies, conditions, created_at, modified_at
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8,
+        $9, $10, $11, $12, $13, $14, $15, $16
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        name = excluded.name,
+        dob = excluded.dob,
+        age = excluded.age,
+        gender = excluded.gender,
+        phone = excluded.phone,
+        email = excluded.email,
+        address = excluded.address,
+        emergencycontactname = excluded.emergencycontactname,
+        emergencycontactrelation = excluded.emergencycontactrelation,
+        emergencycontactphone = excluded.emergencycontactphone,
+        bloodgroup = excluded.bloodgroup,
+        allergies = excluded.allergies,
+        conditions = excluded.conditions,
+        created_at = excluded.created_at,
+        modified_at = excluded.modified_at
+      `
+      ,
+      [
+        p.id, p.name, p.dob, p.age, p.gender, p.phone, p.email, p.address,
+        p.emergencycontactname, p.emergencycontactrelation, p.emergencycontactphone,
+        p.bloodgroup, p.allergies, p.conditions, p.created_at, p.modified_at
+      ]
+    );
+  }
 };


### PR DESCRIPTION
Suppose users have opened the website in two tabs and they add respective entries so both would be added and reflected in at both places instantly without reload.